### PR TITLE
Implement a proper caching and asynchronous execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,20 @@ On the other hand, `_hosts` caches all hosts for autocompletion only once, and t
 ## Solution
 The [hoco.zsh](./hoco.zsh) solves both `_hosts` flaws:
 
-- It updates the cache once per `$HOCO_CACHE_TTL` period (600 by default)
-- It allows to update list of hosts dynamically. Each binary or function in `$HOCO_FUNCTIONS` array is executed asynchronously via [zsh-async](https://github.com/mafredri/zsh-async). The list of hosts for completion is updated on readiness.
+- It updates the cache once per `$HOCO_CACHE_AGE` period, the default is 10 minutes
+- It allows to update list of hosts dynamically. Each binary or function in `$HOCO_FUNCTIONS` array is executed asynchronously. The list of hosts for completion is updated on readiness.
+
+### Usage
+
+The only thing you need to do is:
+
+```
+source hoco.zsh
+some-function() {
+  echo host1 host2 # it does not matter if hosts are separated by spaces
+  echo host3	host4 # or by new lines (LF), or by tabs
+}
+HOCO_FUNCTIONS=(some-function)
+
+ssh <tab>
+```

--- a/hoco.zsh
+++ b/hoco.zsh
@@ -23,18 +23,19 @@
 # - Use async module to not block the flow
 # - Preserve the original _hosts function as _hosts_orig
 # - Adds configurable cache expiring for _cache_hosts
-# - Executes each function in HOCO_FUNCTIONS and adds new line separated values to _cache_hosts
+# - Executes each function in HOCO_FUNCTIONS and adds tabs, new lines and space separated values to _cache_hosts
 #
 #################
 # CONFIGURATION #
 #################
 #
-# HOCO means hosts completion
+# HOCO stands for hosts completion
 #
-# HOCO_CACHE_TTL: cache expiration timeout in seconds, default 600
+# HOCO_CACHE_AGE: cache expiration in `m+10` format for (mm+10), see ZSHEXPN(1) `modification time`
+#                 default: m+10
 # HOCO_FUNCTIONS: array of functions or commands to get hosts.
-#   Only single words are accepted, no arguments are allowed.
-#   The output should be "one host per line"
+#                 Only single words are accepted, no arguments are allowed.
+#                 The output will be split to arguments by '\n', '\t' and space symbols
 #
 
 
@@ -43,749 +44,137 @@ if ! (( $_HOCO_INIT_DONE )); then
   typeset -g _HOCO_INIT_DONE=1
 
   # _hosts needs to be intiated before tweaking
-  _hosts 2>/dev/null >&1 || true
+  _hosts &>/dev/null || :
 
   eval "$(type -f _hosts | sed -r '1 s/_hosts/_hosts_orig/')"
+
+  zstyle -t ":completion:${curcontext}:" use-cache || \
+    echo "The $0 requires 'zstyle :completion:* use-cache on', otherwise it's updated only on start" >&2
 fi
 
-__hosts_cache_callback() {
-  ((_HOCO_RUNNING_JOBS--))
+__hoco_cache_callback() {
+  local fd="$1" curcontext func cache_name func_output
+  local -a args
+  # Remove handlers for the current descriptor
+  zle -F "$fd"
 
-  # It's 99.9% impossible to have empty original _cache_hosts,
-  # but it's checked before filling originally. We should wait untill it's set
-  while (( $+_cache_hosts == 0 )); do
-    sleep 0.1
-  done
+  {
+    # Get curcontext, function, and cache_name and close the descriptor
+    read -ru $fd -d '|' -- curcontext
+    read -ru $fd -d '|' -- func
+    read -ru $fd -d '|' -- cache_name
+    read -ru $fd  -- func_output
 
-  # $2: exit status; $3: stdout
-  [[ "$2" == 0 ]] && _cache_hosts+=("${(f)3}")
+    # A few steps to split by '\n', '\t' and ' '
+    set -A ${cache_name} "${(ps:\n:)func_output}"
+    func_output="${(Ppj:\t:)cache_name}"
+    set -A ${cache_name} "${(ps:\t:)func_output}"
+    func_output="${(Ppj: :)cache_name}"
+    set -A ${cache_name} "${(ps: :)func_output}"
 
-  # cleaunup for the last job
-  if (( _HOCO_RUNNING_JOBS == 0 )); then
-    async_unregister_callback hosts_cache_updater
-    async_stop_worker hosts_cache_updater
-  fi
+    _store_cache ${cache_name#_} ${cache_name}
+    # Wait if original $_cache_hosts is empty
+    while (( $#_cache_hosts == 0 )); do
+      sleep 0.1
+    done
+    set -A _cache_hosts ${_cache_hosts} ${(P)cache_name}
+    # Avoid race condition
+    while ! [[ "$_hoco_async_runs[${func}]" ]]; do
+      sleep 0.1
+    done
+  } always {
+    exec {fd}<&-
+    unset _hoco_async_runs[${func}]
+  }
 }
 
-# Arguments:
-# $1 - cache_age
-__hosts_cache_update() {
-  # if cache age is twice older than ${HOCO_CACHE_TTL:-600}, then it's definitely an issue
-  # with long runnung tasks, abort them
-  if (( ${HOCO_CACHE_TTL:-600} < ${1} / 2 )); then
-    unset _HOCO_UPDATE_RUNNING_SINCE
-    async_flush_jobs hosts_cache_updater
-    async_unregister_callback hosts_cache_updater
-    async_stop_worker hosts_cache_updater
-  fi
-  (( ${_HOCO_UPDATE_RUNNING_SINCE} )) && return 0
-  _HOCO_CACHE_UPDATED=${EPOCHSECONDS}
-  unset _cache_hosts
+__hoco_original_cache_callback() {
+  local fd="$1"
+  # Remove handlers for the current descriptor
+  zle -F "$fd"
 
-  # starting worker that runs only one unic function with notifications
-  async_start_worker hosts_cache_updater -n -u
-  async_register_callback hosts_cache_updater __hosts_cache_callback
+  {
+    # Wait for _hosts_orig finished and populated $_cache_hosts
+    while (( ${#_cache_hosts} == 0 )); do
+      sleep 0.1
+    done
+    # Get curcontext
+    read -ru $fd -- curcontext
 
-  _HOCO_RUNNING_JOBS=${#HOCO_FUNCTIONS}
-  for func (${HOCO_FUNCTIONS}); do
-    async_job hosts_cache_updater ${func}
-  done
+    # Collect results of already finished functions
+    # If the $func already finished, then it may be missed in _cache_hosts
+    for func (${hoco_functions}); do
+      if ! (( $#_hoco_async_runs[$func] )); then
+        cache_name=_hoco_${func}
+        set -A _cache_hosts ${_cache_hosts} ${(P)cache_name}
+      fi
+    done
+    func=hoco-orig_cache_hosts
+    _store_cache "${func}" _cache_hosts
+    # Avoid race condition
+    while ! [[ "$_hoco_async_runs[${func}]" ]]; do
+      sleep 0.1
+    done
+  } always {
+    exec {fd}<&-
+    unset _hoco_async_runs["${func}"]
+  }
 }
 
 _hosts() {
-  # Should be cache updated or not
-  local cache_age
-  cache_age=$((EPOCHSECONDS - _HOCO_CACHE_UPDATED))
-  if (( ${HOCO_CACHE_TTL:-600} < ${cache_age} )); then
-    __hosts_cache_update ${cache_age}
+  local update_policy
+  zstyle -s ":completion:${curcontext}:" cache-policy update_policy
+  if [[ -z "$update_policy" ]]; then
+    zstyle ":completion:${curcontext}:" cache-policy __hoco_cache_update_policy
+  fi
+
+  # Deduplicate HOCO_FUNCTIONS
+  local -aU hoco_functions=(${HOCO_FUNCTIONS})
+  # The global associated array for pids of async functions
+  typeset -Ag _hoco_async_runs
+
+  for func (${hoco_functions}); do
+    cache_name=_hoco_${func}
+    if ( [[ ${(P)+cache_name} -eq 0 ]] || _cache_invalid ${cache_name#_} ) &&
+        ! _retrieve_cache ${cache_name#_}; then
+      typeset -agU _hoco_${func}
+      # Avoid double run
+      [[ "$_hoco_async_runs[${func}]" ]] && continue
+
+      local fd
+      exec {fd}< <( # launch cache fillup in a handler to have the same shell environment
+        local output="${curcontext}|${func}|${cache_name}|$(${func})"
+        print -r -- "${output}"
+      )
+      _hoco_async_runs[${func}]="$sysparams[procsubstpid]"
+      zle -F "${fd}" __hoco_cache_callback
+    fi
+  done
+
+  # Original cache from upstream _hosts function. Never try to retrieve it
+  if (( ${#_cache_hosts} == 0 )) || _cache_invalid hoco-orig_cache_hosts; then
+    unset _cache_hosts
+    local fd
+    exec {fd}< <( # launch cache fillup in a handler to have the same shell environment
+      print -r -- ${curcontext} # preserve $curcontext
+    )
+    _hoco_async_runs[hoco-orig_cache_hosts]="$sysparams[procsubstpid]"
+    zle -F "${fd}" __hoco_original_cache_callback
   fi
 
   # original logic
   _hosts_orig
 }
 
+__hoco_cache_update_policy() {
+  local -a old exists
+  local check=$1
 
-
-
-if ! (( ASYNC_INIT_DONE )); then
-# The async is vendored only if not loaded
-#
-# The code for an async work is nicely borrowed from https://github.com/mafredri/zsh-async
-# Licensed under MIT
-#
-######################
-# BEGIN ASYNC VENDOR #
-######################
-# shellcheck disable=SC0000-SC9999
-#
-# zsh-async
-#
-# version: v1.8.5
-# author: Mathias Fredriksson
-# url: https://github.com/mafredri/zsh-async
-#
-
-typeset -g ASYNC_VERSION=1.8.5
-# Produce debug output from zsh-async when set to 1.
-typeset -g ASYNC_DEBUG=${ASYNC_DEBUG:-0}
-
-# Execute commands that can manipulate the environment inside the async worker. Return output via callback.
-_async_eval() {
-	local ASYNC_JOB_NAME
-	# Rename job to _async_eval and redirect all eval output to cat running
-	# in _async_job. Here, stdout and stderr are not separated for
-	# simplicity, this could be improved in the future.
-	{
-		eval "$@"
-	} &> >(ASYNC_JOB_NAME=[async/eval] _async_job 'command -p cat')
+  # rebuild if cache is more than 10 minutes or does not exist
+  old=( "$check"(m${HOCO_CACHE_AGE:-m+10}) )
+  exists=( "$check"(.) )
+  { (( $#old )) || ! (( $#exists )) } && return 0
+  return 1
 }
 
-# Wrapper for jobs executed by the async worker, gives output in parseable format with execution time
-_async_job() {
-	# Disable xtrace as it would mangle the output.
-	setopt localoptions noxtrace
-
-	# Store start time for job.
-	float -F duration=$EPOCHREALTIME
-
-	# Run the command and capture both stdout (`eval`) and stderr (`cat`) in
-	# separate subshells. When the command is complete, we grab write lock
-	# (mutex token) and output everything except stderr inside the command
-	# block, after the command block has completed, the stdin for `cat` is
-	# closed, causing stderr to be appended with a $'\0' at the end to mark the
-	# end of output from this job.
-	local jobname=${ASYNC_JOB_NAME:-$1} out
-	out="$(
-		local stdout stderr ret tok
-		{
-			stdout=$(eval "$@")
-			ret=$?
-			duration=$(( EPOCHREALTIME - duration ))  # Calculate duration.
-			print -r -n - $'\0'${(q)jobname} $ret ${(q)stdout} $duration
-		} 2> >(stderr=$(command -p cat) && print -r -n - " "${(q)stderr}$'\0')
-	)"
-	if [[ $out != $'\0'*$'\0' ]]; then
-		# Corrupted output (aborted job?), skipping.
-		return
-	fi
-
-	# Grab mutex lock, stalls until token is available.
-	read -r -k 1 -p tok || return 1
-
-	# Return output (<job_name> <return_code> <stdout> <duration> <stderr>).
-	print -r -n - "$out"
-
-	# Unlock mutex by inserting a token.
-	print -n -p $tok
-}
-
-# The background worker manages all tasks and runs them without interfering with other processes
-_async_worker() {
-	# Reset all options to defaults inside async worker.
-	emulate -R zsh
-
-	# Make sure monitor is unset to avoid printing the
-	# pids of child processes.
-	unsetopt monitor
-
-	# Redirect stderr to `/dev/null` in case unforseen errors produced by the
-	# worker. For example: `fork failed: resource temporarily unavailable`.
-	# Some older versions of zsh might also print malloc errors (know to happen
-	# on at least zsh 5.0.2 and 5.0.8) likely due to kill signals.
-	exec 2>/dev/null
-
-	# When a zpty is deleted (using -d) all the zpty instances created before
-	# the one being deleted receive a SIGHUP, unless we catch it, the async
-	# worker would simply exit (stop working) even though visible in the list
-	# of zpty's (zpty -L). This has been fixed around the time of Zsh 5.4
-	# (not released).
-	if ! is-at-least 5.4.1; then
-		TRAPHUP() {
-			return 0  # Return 0, indicating signal was handled.
-		}
-	fi
-
-	local -A storage
-	local unique=0
-	local notify_parent=0
-	local parent_pid=0
-	local coproc_pid=0
-	local processing=0
-
-	local -a zsh_hooks zsh_hook_functions
-	zsh_hooks=(chpwd periodic precmd preexec zshexit zshaddhistory)
-	zsh_hook_functions=(${^zsh_hooks}_functions)
-	unfunction $zsh_hooks &>/dev/null   # Deactivate all zsh hooks inside the worker.
-	unset $zsh_hook_functions           # And hooks with registered functions.
-	unset zsh_hooks zsh_hook_functions  # Cleanup.
-
-	close_idle_coproc() {
-		local -a pids
-		pids=(${${(v)jobstates##*:*:}%\=*})
-
-		# If coproc (cat) is the only child running, we close it to avoid
-		# leaving it running indefinitely and cluttering the process tree.
-		if  (( ! processing )) && [[ $#pids = 1 ]] && [[ $coproc_pid = $pids[1] ]]; then
-			coproc :
-			coproc_pid=0
-		fi
-	}
-
-	child_exit() {
-		close_idle_coproc
-
-		# On older version of zsh (pre 5.2) we notify the parent through a
-		# SIGWINCH signal because `zpty` did not return a file descriptor (fd)
-		# prior to that.
-		if (( notify_parent )); then
-			# We use SIGWINCH for compatibility with older versions of zsh
-			# (pre 5.1.1) where other signals (INFO, ALRM, USR1, etc.) could
-			# cause a deadlock in the shell under certain circumstances.
-			kill -WINCH $parent_pid
-		fi
-	}
-
-	# Register a SIGCHLD trap to handle the completion of child processes.
-	trap child_exit CHLD
-
-	# Process option parameters passed to worker.
-	while getopts "np:uz" opt; do
-		case $opt in
-			n) notify_parent=1;;
-			p) parent_pid=$OPTARG;;
-			u) unique=1;;
-			z) notify_parent=0;;  # Uses ZLE watcher instead.
-		esac
-	done
-
-	# Terminate all running jobs, note that this function does not
-	# reinstall the child trap.
-	terminate_jobs() {
-		trap - CHLD   # Ignore child exits during kill.
-		coproc :      # Quit coproc.
-		coproc_pid=0  # Reset pid.
-
-		if is-at-least 5.4.1; then
-			trap '' HUP    # Catch the HUP sent to this process.
-			kill -HUP -$$  # Send to entire process group.
-			trap - HUP     # Disable HUP trap.
-		else
-			# We already handle HUP for Zsh < 5.4.1.
-			kill -HUP -$$  # Send to entire process group.
-		fi
-	}
-
-	killjobs() {
-		local tok
-		local -a pids
-		pids=(${${(v)jobstates##*:*:}%\=*})
-
-		# No need to send SIGHUP if no jobs are running.
-		(( $#pids == 0 )) && continue
-		(( $#pids == 1 )) && [[ $coproc_pid = $pids[1] ]] && continue
-
-		# Grab lock to prevent half-written output in case a child
-		# process is in the middle of writing to stdin during kill.
-		(( coproc_pid )) && read -r -k 1 -p tok
-
-		terminate_jobs
-		trap child_exit CHLD  # Reinstall child trap.
-	}
-
-	local request do_eval=0
-	local -a cmd
-	while :; do
-		# Wait for jobs sent by async_job.
-		read -r -d $'\0' request || {
-			# Unknown error occurred while reading from stdin, the zpty
-			# worker is likely in a broken state, so we shut down.
-			terminate_jobs
-
-			# Stdin is broken and in case this was an unintended
-			# crash, we try to report it as a last hurrah.
-			print -r -n $'\0'"'[async]'" $(( 127 + 3 )) "''" 0 "'$0:$LINENO: zpty fd died, exiting'"$'\0'
-
-			# We use `return` to abort here because using `exit` may
-			# result in an infinite loop that never exits and, as a
-			# result, high CPU utilization.
-			return $(( 127 + 1 ))
-		}
-
-		# We need to clean the input here because sometimes when a zpty
-		# has died and been respawned, messages will be prefixed with a
-		# carraige return (\r, or \C-M).
-		request=${request#$'\C-M'}
-
-		# Check for non-job commands sent to worker
-		case $request in
-			_killjobs)    killjobs; continue;;
-			_async_eval*) do_eval=1;;
-		esac
-
-		# Parse the request using shell parsing (z) to allow commands
-		# to be parsed from single strings and multi-args alike.
-		cmd=("${(z)request}")
-
-		# Name of the job (first argument).
-		local job=$cmd[1]
-
-		# Check if a worker should perform unique jobs, unless
-		# this is an eval since they run synchronously.
-		if (( !do_eval )) && (( unique )); then
-			# Check if a previous job is still running, if yes,
-			# skip this job and let the previous one finish.
-			for pid in ${${(v)jobstates##*:*:}%\=*}; do
-				if [[ ${storage[$job]} == $pid ]]; then
-					continue 2
-				fi
-			done
-		fi
-
-		# Guard against closing coproc from trap before command has started.
-		processing=1
-
-		# Because we close the coproc after the last job has completed, we must
-		# recreate it when there are no other jobs running.
-		if (( ! coproc_pid )); then
-			# Use coproc as a mutex for synchronized output between children.
-			coproc command -p cat
-			coproc_pid="$!"
-			# Insert token into coproc
-			print -n -p "t"
-		fi
-
-		if (( do_eval )); then
-			shift cmd  # Strip _async_eval from cmd.
-			_async_eval $cmd
-		else
-			# Run job in background, completed jobs are printed to stdout.
-			_async_job $cmd &
-			# Store pid because zsh job manager is extremely unflexible (show jobname as non-unique '$job')...
-			storage[$job]="$!"
-		fi
-
-		processing=0  # Disable guard.
-
-		if (( do_eval )); then
-			do_eval=0
-
-			# When there are no active jobs we can't rely on the CHLD trap to
-			# manage the coproc lifetime.
-			close_idle_coproc
-		fi
-	done
-}
-
-#
-# Get results from finished jobs and pass it to the to callback function. This is the only way to reliably return the
-# job name, return code, output and execution time and with minimal effort.
-#
-# If the async process buffer becomes corrupt, the callback will be invoked with the first argument being `[async]` (job
-# name), non-zero return code and fifth argument describing the error (stderr).
-#
-# usage:
-# 	async_process_results <worker_name> <callback_function>
-#
-# callback_function is called with the following parameters:
-# 	$1 = job name, e.g. the function passed to async_job
-# 	$2 = return code
-# 	$3 = resulting stdout from execution
-# 	$4 = execution time, floating point e.g. 2.05 seconds
-# 	$5 = resulting stderr from execution
-#	$6 = has next result in buffer (0 = buffer empty, 1 = yes)
-#
-async_process_results() {
-	setopt localoptions unset noshwordsplit noksharrays noposixidentifiers noposixstrings
-
-	local worker=$1
-	local callback=$2
-	local caller=$3
-	local -a items
-	local null=$'\0' data
-	integer -l len pos num_processed has_next
-
-	typeset -gA ASYNC_PROCESS_BUFFER
-
-	# Read output from zpty and parse it if available.
-	while zpty -r -t $worker data 2>/dev/null; do
-		ASYNC_PROCESS_BUFFER[$worker]+=$data
-		len=${#ASYNC_PROCESS_BUFFER[$worker]}
-		pos=${ASYNC_PROCESS_BUFFER[$worker][(i)$null]}  # Get index of NULL-character (delimiter).
-
-		# Keep going until we find a NULL-character.
-		if (( ! len )) || (( pos > len )); then
-			continue
-		fi
-
-		while (( pos <= len )); do
-			# Take the content from the beginning, until the NULL-character and
-			# perform shell parsing (z) and unquoting (Q) as an array (@).
-			items=("${(@Q)${(z)ASYNC_PROCESS_BUFFER[$worker][1,$pos-1]}}")
-
-			# Remove the extracted items from the buffer.
-			ASYNC_PROCESS_BUFFER[$worker]=${ASYNC_PROCESS_BUFFER[$worker][$pos+1,$len]}
-
-			len=${#ASYNC_PROCESS_BUFFER[$worker]}
-			if (( len > 1 )); then
-				pos=${ASYNC_PROCESS_BUFFER[$worker][(i)$null]}  # Get index of NULL-character (delimiter).
-			fi
-
-			has_next=$(( len != 0 ))
-			if (( $#items == 5 )); then
-				items+=($has_next)
-				$callback "${(@)items}"  # Send all parsed items to the callback.
-				(( num_processed++ ))
-			elif [[ -z $items ]]; then
-				# Empty items occur between results due to double-null ($'\0\0')
-				# caused by commands being both pre and suffixed with null.
-			else
-				# In case of corrupt data, invoke callback with *async* as job
-				# name, non-zero exit status and an error message on stderr.
-				$callback "[async]" 1 "" 0 "$0:$LINENO: error: bad format, got ${#items} items (${(q)items})" $has_next
-			fi
-		done
-	done
-
-	(( num_processed )) && return 0
-
-	# Avoid printing exit value when `setopt printexitvalue` is active.`
-	[[ $caller = trap || $caller = watcher ]] && return 0
-
-	# No results were processed
-	return 1
-}
-
-# Watch worker for output
-_async_zle_watcher() {
-	setopt localoptions noshwordsplit
-	typeset -gA ASYNC_PTYS ASYNC_CALLBACKS
-	local worker=$ASYNC_PTYS[$1]
-	local callback=$ASYNC_CALLBACKS[$worker]
-
-	if [[ -n $2 ]]; then
-		# from man zshzle(1):
-		# `hup' for a disconnect, `nval' for a closed or otherwise
-		# invalid descriptor, or `err' for any other condition.
-		# Systems that support only the `select' system call always use
-		# `err'.
-
-		# this has the side effect to unregister the broken file descriptor
-		async_stop_worker $worker
-
-		if [[ -n $callback ]]; then
-			$callback '[async]' 2 "" 0 "$0:$LINENO: error: fd for $worker failed: zle -F $1 returned error $2" 0
-		fi
-		return
-	fi;
-
-	if [[ -n $callback ]]; then
-		async_process_results $worker $callback watcher
-	fi
-}
-
-_async_send_job() {
-	setopt localoptions noshwordsplit noksharrays noposixidentifiers noposixstrings
-
-	local caller=$1
-	local worker=$2
-	shift 2
-
-	zpty -t $worker &>/dev/null || {
-		typeset -gA ASYNC_CALLBACKS
-		local callback=$ASYNC_CALLBACKS[$worker]
-
-		if [[ -n $callback ]]; then
-			$callback '[async]' 3 "" 0 "$0:$LINENO: error: no such worker: $worker" 0
-		else
-			print -u2 "$caller: no such async worker: $worker"
-		fi
-		return 1
-	}
-
-	zpty -w $worker "$@"$'\0'
-}
-
-#
-# Start a new asynchronous job on specified worker, assumes the worker is running.
-#
-# Note if you are using a function for the job, it must have been defined before the worker was
-# started or you will get a `command not found` error.
-#
-# usage:
-# 	async_job <worker_name> <my_function> [<function_params>]
-#
-async_job() {
-	setopt localoptions noshwordsplit noksharrays noposixidentifiers noposixstrings
-
-	local worker=$1; shift
-
-	local -a cmd
-	cmd=("$@")
-	if (( $#cmd > 1 )); then
-		cmd=(${(q)cmd})  # Quote special characters in multi argument commands.
-	fi
-
-	_async_send_job $0 $worker "$cmd"
-}
-
-#
-# Evaluate a command (like async_job) inside the async worker, then worker environment can be manipulated. For example,
-# issuing a cd command will change the PWD of the worker which will then be inherited by all future async jobs.
-#
-# Output will be returned via callback, job name will be [async/eval].
-#
-# usage:
-# 	async_worker_eval <worker_name> <my_function> [<function_params>]
-#
-async_worker_eval() {
-	setopt localoptions noshwordsplit noksharrays noposixidentifiers noposixstrings
-
-	local worker=$1; shift
-
-	local -a cmd
-	cmd=("$@")
-	if (( $#cmd > 1 )); then
-		cmd=(${(q)cmd})  # Quote special characters in multi argument commands.
-	fi
-
-	# Quote the cmd in case RC_EXPAND_PARAM is set.
-	_async_send_job $0 $worker "_async_eval $cmd"
-}
-
-# This function traps notification signals and calls all registered callbacks
-_async_notify_trap() {
-	setopt localoptions noshwordsplit
-
-	local k
-	for k in ${(k)ASYNC_CALLBACKS}; do
-		async_process_results $k ${ASYNC_CALLBACKS[$k]} trap
-	done
-}
-
-#
-# Register a callback for completed jobs. As soon as a job is finnished, async_process_results will be called with the
-# specified callback function. This requires that a worker is initialized with the -n (notify) option.
-#
-# usage:
-# 	async_register_callback <worker_name> <callback_function>
-#
-async_register_callback() {
-	setopt localoptions noshwordsplit nolocaltraps
-
-	typeset -gA ASYNC_PTYS ASYNC_CALLBACKS
-	local worker=$1; shift
-
-	ASYNC_CALLBACKS[$worker]="$*"
-
-	# Enable trap when the ZLE watcher is unavailable, allows
-	# workers to notify (via -n) when a job is done.
-	if [[ ! -o interactive ]] || [[ ! -o zle ]]; then
-		trap '_async_notify_trap' WINCH
-	elif [[ -o interactive ]] && [[ -o zle ]]; then
-		local fd w
-		for fd w in ${(@kv)ASYNC_PTYS}; do
-			if [[ $w == $worker ]]; then
-				zle -F $fd _async_zle_watcher  # Register the ZLE handler.
-				break
-			fi
-		done
-	fi
-}
-
-#
-# Unregister the callback for a specific worker.
-#
-# usage:
-# 	async_unregister_callback <worker_name>
-#
-async_unregister_callback() {
-	typeset -gA ASYNC_CALLBACKS
-
-	unset "ASYNC_CALLBACKS[$1]"
-}
-
-#
-# Flush all current jobs running on a worker. This will terminate any and all running processes under the worker, use
-# with caution.
-#
-# usage:
-# 	async_flush_jobs <worker_name>
-#
-async_flush_jobs() {
-	setopt localoptions noshwordsplit
-
-	local worker=$1; shift
-
-	# Check if the worker exists
-	zpty -t $worker &>/dev/null || return 1
-
-	# Send kill command to worker
-	async_job $worker "_killjobs"
-
-	# Clear the zpty buffer.
-	local junk
-	if zpty -r -t $worker junk '*'; then
-		(( ASYNC_DEBUG )) && print -n "async_flush_jobs $worker: ${(V)junk}"
-		while zpty -r -t $worker junk '*'; do
-			(( ASYNC_DEBUG )) && print -n "${(V)junk}"
-		done
-		(( ASYNC_DEBUG )) && print
-	fi
-
-	# Finally, clear the process buffer in case of partially parsed responses.
-	typeset -gA ASYNC_PROCESS_BUFFER
-	unset "ASYNC_PROCESS_BUFFER[$worker]"
-}
-
-#
-# Start a new async worker with optional parameters, a worker can be told to only run unique tasks and to notify a
-# process when tasks are complete.
-#
-# usage:
-# 	async_start_worker <worker_name> [-u] [-n] [-p <pid>]
-#
-# opts:
-# 	-u unique (only unique job names can run)
-# 	-n notify through SIGWINCH signal
-# 	-p pid to notify (defaults to current pid)
-#
-async_start_worker() {
-	setopt localoptions noshwordsplit noclobber
-
-	local worker=$1; shift
-	local -a args
-	args=("$@")
-	zpty -t $worker &>/dev/null && return
-
-	typeset -gA ASYNC_PTYS
-	typeset -h REPLY
-	typeset has_xtrace=0
-
-	if [[ -o interactive ]] && [[ -o zle ]]; then
-		# Inform the worker to ignore the notify flag and that we're
-		# using a ZLE watcher instead.
-		args+=(-z)
-
-		if (( ! ASYNC_ZPTY_RETURNS_FD )); then
-			# When zpty doesn't return a file descriptor (on older versions of zsh)
-			# we try to guess it anyway.
-			integer -l zptyfd
-			exec {zptyfd}>&1  # Open a new file descriptor (above 10).
-			exec {zptyfd}>&-  # Close it so it's free to be used by zpty.
-		fi
-	fi
-
-	# Workaround for stderr in the main shell sometimes (incorrectly) being
-	# reassigned to /dev/null by the reassignment done inside the async
-	# worker.
-	# See https://github.com/mafredri/zsh-async/issues/35.
-	integer errfd=-1
-
-	# Redirect of errfd is broken on zsh 5.0.2.
-	if is-at-least 5.0.8; then
-		exec {errfd}>&2
-	fi
-
-	# Make sure async worker is started without xtrace
-	# (the trace output interferes with the worker).
-	[[ -o xtrace ]] && {
-		has_xtrace=1
-		unsetopt xtrace
-	}
-
-	if (( errfd != -1 )); then
-		zpty -b $worker _async_worker -p $$ $args 2>&$errfd
-	else
-		zpty -b $worker _async_worker -p $$ $args
-	fi
-	local ret=$?
-
-	# Re-enable it if it was enabled, for debugging.
-	(( has_xtrace )) && setopt xtrace
-	(( errfd != -1 )) && exec {errfd}>& -
-
-	if (( ret )); then
-		async_stop_worker $worker
-		return 1
-	fi
-
-	if ! is-at-least 5.0.8; then
-		# For ZSH versions older than 5.0.8 we delay a bit to give
-		# time for the worker to start before issuing commands,
-		# otherwise it will not be ready to receive them.
-		sleep 0.001
-	fi
-
-	if [[ -o interactive ]] && [[ -o zle ]]; then
-		if (( ! ASYNC_ZPTY_RETURNS_FD )); then
-			REPLY=$zptyfd  # Use the guessed value for the file desciptor.
-		fi
-
-		ASYNC_PTYS[$REPLY]=$worker  # Map the file desciptor to the worker.
-	fi
-}
-
-#
-# Stop one or multiple workers that are running, all unfetched and incomplete work will be lost.
-#
-# usage:
-# 	async_stop_worker <worker_name_1> [<worker_name_2>]
-#
-async_stop_worker() {
-	setopt localoptions noshwordsplit
-
-	local ret=0 worker k v
-	for worker in $@; do
-		# Find and unregister the zle handler for the worker
-		for k v in ${(@kv)ASYNC_PTYS}; do
-			if [[ $v == $worker ]]; then
-				zle -F $k
-				unset "ASYNC_PTYS[$k]"
-			fi
-		done
-		async_unregister_callback $worker
-		zpty -d $worker 2>/dev/null || ret=$?
-
-		# Clear any partial buffers.
-		typeset -gA ASYNC_PROCESS_BUFFER
-		unset "ASYNC_PROCESS_BUFFER[$worker]"
-	done
-
-	return $ret
-}
-
-#
-# Initialize the required modules for zsh-async. To be called before using the zsh-async library.
-#
-# usage:
-# 	async_init
-#
-async_init() {
-	(( ASYNC_INIT_DONE )) && return
-	typeset -g ASYNC_INIT_DONE=1
-
-	zmodload zsh/zpty
-	zmodload zsh/datetime
-
-	# Load is-at-least for reliable version check.
-	autoload -Uz is-at-least
-
-	# Check if zsh/zpty returns a file descriptor or not,
-	# shell must also be interactive with zle enabled.
-	typeset -g ASYNC_ZPTY_RETURNS_FD=0
-	[[ -o interactive ]] && [[ -o zle ]] && {
-		typeset -h REPLY
-		zpty _async_test :
-		(( REPLY )) && ASYNC_ZPTY_RETURNS_FD=1
-		zpty -d _async_test
-	}
-}
-
-async_init
-# shellcheck enable=SC0000-SC9999
-#############
-# END ASYNC #
-#############
-fi
-
-# vim: filetype=zsh
+# vi: filetype=zsh


### PR DESCRIPTION
The script used to have vendored https://github.com/mafredri/zsh-async and to use a custom caching system.

Now I completely rewrote it to use `zle -F` and standard zsh caching functions `_store_cache`, `_retrieve_cache`, and `_cache_invalid`. Thanks to it, now the cache even will be shared between different shell instances.

This PR fixes #2 and fixes #3 